### PR TITLE
Use block delta when computing translator start block

### DIFF
--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use serde::Deserialize;
-use telos_translator_rs::translator::TranslatorConfig;
+use telos_translator_rs::{translator::TranslatorConfig, types::translator_types::ChainId};
 
 /// Telos Consensus Client CLI Arguments
 #[derive(Parser, Debug, Clone)]
@@ -20,7 +20,7 @@ pub struct AppConfig {
     pub log_level: String,
 
     /// EVM Chain id, Telos mainnet is 40 and testnet is 41
-    pub chain_id: u64,
+    pub chain_id: ChainId,
 
     /// Execution API http endpoint (JWT protected endpoint on reth)
     pub execution_endpoint: String,
@@ -70,16 +70,10 @@ pub struct AppConfig {
 
 impl From<&AppConfig> for TranslatorConfig {
     fn from(config: &AppConfig) -> Self {
-        let block_delta = match config.chain_id {
-            40 => 36,
-            41 => 57,
-            _ => 0,
-        };
         Self {
-            chain_id: config.chain_id,
+            chain_id: config.chain_id.clone(),
             evm_start_block: config.evm_start_block,
             evm_stop_block: config.evm_stop_block,
-            block_delta,
             prev_hash: config.prev_hash.clone(),
             validate_hash: config.validate_hash.clone(),
             http_endpoint: config.chain_endpoint.clone(),

--- a/client/tests/ship_read.rs
+++ b/client/tests/ship_read.rs
@@ -11,6 +11,7 @@ use telos_consensus_client::config::{AppConfig, CliArgs};
 use telos_consensus_client::json_rpc::JsonRequestBody;
 use telos_translator_rs::block::TelosEVMBlock;
 use telos_translator_rs::translator::Translator;
+use telos_translator_rs::types::translator_types::ChainId;
 use testcontainers::core::ContainerPort::Tcp;
 use testcontainers::{runners::AsyncRunner, ContainerAsync, GenericImage};
 use tokio::sync::oneshot::Sender;
@@ -213,7 +214,7 @@ async fn evm_deploy() {
 
     let config = AppConfig {
         log_level: "debug".to_string(),
-        chain_id: 41,
+        chain_id: ChainId(41),
         execution_endpoint: format!("http://localhost:{MOCK_EXECUTION_API_PORT}"),
         jwt_secret: "57ea261c64b8a871e4df3f0c790efd0d02f9846e5085483e3098f30118fd1520".to_string(),
         ship_endpoint: format!("ws://localhost:{port_18999}"),

--- a/translator/src/translator.rs
+++ b/translator/src/translator.rs
@@ -1,5 +1,6 @@
 use crate::block::{ProcessingEVMBlock, TelosEVMBlock};
 use crate::tasks::{evm_block_processor, final_processor, raw_deserializer, ship_reader};
+use crate::types::translator_types::ChainId;
 use antelope::api::client::APIClient;
 use antelope::api::default_provider::DefaultProvider;
 use eyre::{eyre, Context, Result};
@@ -16,10 +17,9 @@ pub fn default_channel_size() -> usize {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TranslatorConfig {
-    pub chain_id: u64,
+    pub chain_id: ChainId,
     pub evm_start_block: u32,
     pub evm_stop_block: Option<u32>,
-    pub block_delta: u32,
     pub prev_hash: String,
     pub validate_hash: Option<String>,
 

--- a/translator/src/types/env.rs
+++ b/translator/src/types/env.rs
@@ -13,11 +13,10 @@ pub const ZERO_HASH_HEX: &str = "00000000000000000000000000000000000000000000000
 lazy_static! {
     pub static ref ZERO_HASH: FixedBytes<32> = FixedBytes::from_str(ZERO_HASH_HEX).unwrap();
     pub static ref MAINNET_GENESIS_CONFIG: TranslatorConfig = TranslatorConfig {
-        chain_id: 40,
+        chain_id: 40.into(),
 
         evm_start_block: 37,
         evm_stop_block: None,
-        block_delta: 36,
 
         prev_hash: ZERO_HASH_HEX.to_string(),
         validate_hash: Some(
@@ -32,11 +31,10 @@ lazy_static! {
         final_message_channel_size: default_channel_size()
     };
     pub static ref MAINNET_DEPLOY_CONFIG: TranslatorConfig = TranslatorConfig {
-        chain_id: 40,
+        chain_id: 40.into(),
 
         evm_start_block: 180698860,
         evm_stop_block: None,
-        block_delta: 36,
 
         prev_hash: "757720a8e51c63ef1d4f907d6569dacaa965e91c2661345902de18af11f81063".to_string(),
         validate_hash: Some(
@@ -51,11 +49,10 @@ lazy_static! {
         final_message_channel_size: default_channel_size()
     };
     pub static ref TESTNET_GENESIS_CONFIG: TranslatorConfig = TranslatorConfig {
-        chain_id: 41,
+        chain_id: 41.into(),
 
         evm_start_block: 58,
         evm_stop_block: None,
-        block_delta: 57,
 
         prev_hash: ZERO_HASH_HEX.to_string(),
         validate_hash: Some(
@@ -70,11 +67,10 @@ lazy_static! {
         final_message_channel_size: default_channel_size()
     };
     pub static ref TESTNET_DEPLOY_CONFIG: TranslatorConfig = TranslatorConfig {
-        chain_id: 41,
+        chain_id: 41.into(),
 
         evm_start_block: 136393814,
         evm_stop_block: None,
-        block_delta: 57,
 
         prev_hash: "8e149fd918bad5a4adfe6f17478e46643f7db7292a2b7b9247f48dc85bdeec94".to_string(),
         validate_hash: None,

--- a/translator/src/types/translator_types.rs
+++ b/translator/src/types/translator_types.rs
@@ -10,6 +10,7 @@ use antelope::chain::name::Name;
 use futures_util::stream::{SplitSink, SplitStream};
 use moka::sync::Cache;
 use reth_primitives::revm_primitives::bitvec::macros::internal::funty::Fundamental;
+use serde::{Deserialize, Serialize};
 use std::collections::BinaryHeap;
 use std::net::TcpStream;
 use std::sync::{Arc, Mutex};
@@ -180,6 +181,25 @@ impl Clone for PriorityQueue {
     fn clone(&self) -> Self {
         PriorityQueue {
             heap: Arc::clone(&self.heap),
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct ChainId(pub u64);
+
+impl From<u64> for ChainId {
+    fn from(value: u64) -> Self {
+        ChainId(value)
+    }
+}
+
+impl ChainId {
+    pub fn block_delta(&self) -> u32 {
+        match self.0 {
+            40 => 36,
+            41 => 57,
+            _ => 0,
         }
     }
 }

--- a/translator/tests/mock_fork.rs
+++ b/translator/tests/mock_fork.rs
@@ -41,6 +41,17 @@ async fn mock_fork() {
     // configure a fork from block 30 to 25
     let mock_client = LeapMockClient::new(&format!("http://localhost:{cntr_control_port}"));
 
+    let config = TranslatorConfig {
+        http_endpoint: format!("http://localhost:{cntr_http_port}",),
+        ship_endpoint: format!("ws://localhost:{cntr_ship_port}",),
+        validate_hash: None,
+        evm_start_block: 2,
+        evm_stop_block: Some(99),
+        ..TESTNET_GENESIS_CONFIG.clone()
+    };
+
+    let block_delta = config.chain_id.block_delta();
+
     let _chain_info = mock_client
         .set_chain(ChainDescriptor {
             chain_id: None,
@@ -50,25 +61,15 @@ async fn mock_fork() {
                 JumpInfo { from: 35, to: 20 }, // normal fork
                 JumpInfo { from: 80, to: 3 },  // long fork
             ],
-            chain_start_block: 1,
-            chain_end_block: 100,
-            session_start_block: 2,
-            session_stop_block: 100,
+            chain_start_block: block_delta,
+            chain_end_block: 100 + block_delta,
+            session_start_block: 2 + block_delta,
+            session_stop_block: 100 + block_delta,
             http_port: Some(chain_http_port),
             ship_port: Some(chain_ship_port),
         })
         .await
         .unwrap();
-
-    let config = TranslatorConfig {
-        http_endpoint: format!("http://localhost:{cntr_http_port}",),
-        ship_endpoint: format!("ws://localhost:{cntr_ship_port}",),
-        validate_hash: None,
-        evm_start_block: 2,
-        evm_stop_block: Some(99),
-        block_delta: 0,
-        ..TESTNET_GENESIS_CONFIG.clone()
-    };
 
     let (tx, mut rx) = mpsc::channel::<TelosEVMBlock>(1000);
 

--- a/translator/tests/ship_read.rs
+++ b/translator/tests/ship_read.rs
@@ -42,7 +42,6 @@ async fn evm_deploy() {
         validate_hash: None,
         evm_start_block: 1,
         evm_stop_block: Some(30),
-        block_delta: 57,
         ..TESTNET_GENESIS_CONFIG.clone()
     };
 


### PR DESCRIPTION
When translator start block is computed, we use minimum of latest EVM block and latest LIB stored in database. This PR fixes issue of block delta that was not added to LIB when computing start block/