### PR TITLE
Use modified translator config on start

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -114,12 +114,9 @@ impl ConsensusClient {
             .checked_sub(self.config.evm_start_block)
     }
 
-    pub async fn run(
-        mut self,
-        mut rx: mpsc::Receiver<TelosEVMBlock>,
-        mut lib: Option<data::Block>,
-    ) -> Result<(), Error> {
+    pub async fn run(mut self, mut rx: mpsc::Receiver<TelosEVMBlock>) -> Result<(), Error> {
         let mut batch = vec![];
+        let mut lib: Option<data::Block> = self.db.get_lib()?;
         loop {
             let message = tokio::select! {
                 message = rx.recv() => message,

--- a/client/tests/ship_read.rs
+++ b/client/tests/ship_read.rs
@@ -239,7 +239,7 @@ async fn evm_deploy() {
     let translator = Translator::new((&config.clone()).into());
     let translator_shutdown = translator.shutdown_handle();
 
-    let client_handle = tokio::spawn(client_under_test.run(rx, None));
+    let client_handle = tokio::spawn(client_under_test.run(rx));
     let translator_handle = tokio::spawn(translator.launch(Some(tx)));
     client_handle.await.unwrap().unwrap();
 

--- a/translator/src/translator.rs
+++ b/translator/src/translator.rs
@@ -35,7 +35,7 @@ pub struct TranslatorConfig {
 }
 
 pub struct Translator {
-    config: TranslatorConfig,
+    pub config: TranslatorConfig,
     shutdown_tx: mpsc::Sender<()>,
     shutdown_rx: mpsc::Receiver<()>,
 }


### PR DESCRIPTION
This PR:
Fixes issue with different consensus client and translator configurations
Moves lib to consensus client since client is already mutable on run