### PR TITLE
Reduce log level when fetching name to address.

### DIFF
--- a/translator/src/types/translator_types.rs
+++ b/translator/src/types/translator_types.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use tokio::time::sleep;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 pub type WebsocketTransmitter = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>;
 pub type WebsocketReceiver = SplitStream<WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>>;
@@ -46,7 +46,7 @@ impl NameToAddressCache {
         let address = Name::from_u64(name).as_string();
         let cached = self.cache.get(&name);
 
-        info!("getting {address} cache hit = {:?}", cached.is_some());
+        debug!("getting {address} cache hit = {:?}", cached.is_some());
 
         if cached.is_some() {
             return cached;
@@ -87,7 +87,7 @@ impl NameToAddressCache {
         let evm_contract = Name::from_u64(EOSIO_EVM);
         let address = Name::from_u64(index).as_string();
         let cached = self.index_cache.get(&index);
-        info!("getting index {index} cache hit = {:?}", cached.is_some());
+        debug!("getting index {index} cache hit = {:?}", cached.is_some());
 
         if cached.is_some() {
             return cached;


### PR DESCRIPTION
# Fixes [69](https://github.com/telosnetwork/telos-consensus-client/issues/69)

## Description
Reduce log level to debug on getting the name to address mapping.
<!---
Include a summary of your change and how it solves the issue its related to
-->

## Test scenarios

<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage
-   [ ] I have updated relevant documentation and/or opened a separate issue to cover the updates (Issue URL: )
