### PR TITLE
fix(client): retain branches for crash recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "educe",
+ "num-bigint",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +527,16 @@ name = "ark-ff-asm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -554,6 +581,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +627,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "num-bigint",
+ "serde_with",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "ark-std"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +675,16 @@ name = "ark-std"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
@@ -3779,14 +3853,15 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -384,8 +384,11 @@ impl ConsensusClient {
             validate_payload_status(block.block_num, block.block_hash, &payload_status)?;
             self.db
                 .put_execution_branch_entry(&execution_branch_entry(block)?)?;
-            self.db
-                .prune_execution_branches(block.lib_num, &block.lib_hash)?;
+            self.db.prune_execution_branches(
+                block.lib_num,
+                &block.lib_hash,
+                self.config.latest_blocks_in_db_num,
+            )?;
             debug!(
                 block_number = block.block_num,
                 block_hash = %block.block_hash,

--- a/client/src/data.rs
+++ b/client/src/data.rs
@@ -306,6 +306,7 @@ impl Database {
         &self,
         irreversible_block: u32,
         irreversible_hash: &str,
+        recovery_window: u32,
     ) -> Result<usize, Error> {
         let entries = self.get_execution_branch_entries()?;
         if entries.iter().any(|entry| {
@@ -320,7 +321,12 @@ impl Database {
         let mut batch = WriteBatch::default();
         let mut removed = 0;
         for entry in entries {
-            if should_prune_execution_branch(&entry, irreversible_block, irreversible_hash) {
+            if should_prune_execution_branch(
+                &entry,
+                irreversible_block,
+                irreversible_hash,
+                recovery_window,
+            ) {
                 batch.delete(Self::execution_branch_key(&entry.native_hash));
                 removed += 1;
             }
@@ -381,10 +387,17 @@ fn should_prune_execution_branch(
     entry: &ExecutionBranchEntry,
     irreversible_block: u32,
     irreversible_hash: &str,
+    recovery_window: u32,
 ) -> bool {
-    entry.native_block_number < irreversible_block
-        || (entry.native_block_number == irreversible_block
-            && entry.native_hash != irreversible_hash)
+    if entry.native_block_number == irreversible_block && entry.native_hash != irreversible_hash {
+        return true;
+    }
+
+    // Reth can acknowledge a canonical forkchoice before its latest database pages reach durable
+    // storage. Retain the same recent window as the translator block database so a restart after
+    // abrupt power loss can bind the execution client's recovered head to previously VALID
+    // metadata instead of either guessing its context or becoming permanently unrecoverable.
+    entry.native_block_number < irreversible_block.saturating_sub(recovery_window)
 }
 
 #[cfg(test)]
@@ -458,10 +471,35 @@ mod tests {
             for entry in [&old, &lib, &side_at_lib, &newer_a, &newer_b] {
                 database.put_execution_branch_entry(entry).unwrap();
             }
-            assert_eq!(database.prune_execution_branches(100, "lib").unwrap(), 2);
+            assert_eq!(database.prune_execution_branches(100, "lib", 0).unwrap(), 2);
             assert_eq!(
                 database.get_execution_branch_entries().unwrap(),
                 vec![lib, newer_a, newer_b]
+            );
+        }
+        fs::remove_dir_all(path).unwrap();
+    }
+
+    #[test]
+    fn pruning_retains_a_durable_execution_recovery_window() {
+        let path = temporary_database_path("recovery-window");
+        let too_old = branch(89, "too-old", 1);
+        let recovered_head = branch(90, "recovered-head", 2);
+        let recent = branch(99, "recent", 3);
+        let lib = branch(100, "lib", 4);
+        let side_at_lib = branch(100, "side-at-lib", 5);
+        {
+            let database = Database::open(path.to_str().unwrap()).unwrap();
+            for entry in [&too_old, &recovered_head, &recent, &lib, &side_at_lib] {
+                database.put_execution_branch_entry(entry).unwrap();
+            }
+            assert_eq!(
+                database.prune_execution_branches(100, "lib", 10).unwrap(),
+                2
+            );
+            assert_eq!(
+                database.get_execution_branch_entries().unwrap(),
+                vec![recovered_head, recent, lib]
             );
         }
         fs::remove_dir_all(path).unwrap();

--- a/client/src/main_utils.rs
+++ b/client/src/main_utils.rs
@@ -205,6 +205,11 @@ pub async fn build_consensus_client(
             "Block checkpoint interval must be greater than zero".to_string(),
         ));
     }
+    if config.latest_blocks_in_db_num == 0 {
+        return Err(Error::CannotStartConsensusClient(
+            "Latest-block retention must be greater than zero".to_string(),
+        ));
+    }
     if config.execution_connect_timeout_ms == Some(0)
         || config.execution_request_timeout_ms == Some(0)
         || config.native_request_timeout_ms == Some(0)
@@ -301,7 +306,11 @@ pub async fn build_consensus_client(
     }
 
     if let Some(lib) = lib.as_ref() {
-        let removed = client.db.prune_execution_branches(lib.number, &lib.hash)?;
+        let removed = client.db.prune_execution_branches(
+            lib.number,
+            &lib.hash,
+            client.config.latest_blocks_in_db_num,
+        )?;
         if removed > 0 {
             info!(
                 removed,
@@ -529,6 +538,23 @@ mod tests {
         .unwrap();
 
         assert_eq!(selected.branch, reorged);
+    }
+
+    #[test]
+    fn restart_after_execution_rollback_selects_recent_durable_branch() {
+        let ahead = ExecutionCheckpoint::from(branch(340, "ahead", 304, 5));
+        let recovered = branch(338, "recovered", 302, 6);
+
+        let selected = select_restart_checkpoint(
+            Some(ahead),
+            Some((recovered.evm_block_number, recovered.evm_hash)),
+            std::slice::from_ref(&recovered),
+            false,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(selected.branch, recovered);
     }
 
     #[test]


### PR DESCRIPTION
Retains the configured recent VALID-branch window below native LIB so the companion can bind an execution client head recovered after abrupt storage rollback. Zero retention now fails preflight, and focused tests cover pruning plus rollback checkpoint selection.